### PR TITLE
Windows-compatible file names in summary

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -1,5 +1,6 @@
 'use strict';
 var assert = require('assert');
+var path = require('path');
 
 module.exports = function (grunt) {
   grunt.initConfig({
@@ -73,6 +74,8 @@ module.exports = function (grunt) {
   ]);
 
   grunt.registerTask('checkSummary', 'Check that summary attribute is correctly created', function () {
-		assert.equal(grunt.filerev.summary['test/fixtures/file.png'], 'test/tmp/file.a0539763.png');
+    var src = path.normalize('test/fixtures/file.png');
+    var expected = path.normalize('test/tmp/file.a0539763.png');
+    assert.equal(grunt.filerev.summary[src], expected);
   });
 };

--- a/tasks/filerev.js
+++ b/tasks/filerev.js
@@ -48,7 +48,7 @@ module.exports = function (grunt) {
           grunt.file.copy(file, resultPath);
         }
 
-        filerev.summary[file] = path.join(dirname, newName);
+        filerev.summary[path.normalize(file)] = path.join(dirname, newName);
         grunt.log.writeln('✔ '.green + file + (' changed to ').grey + filerev.summary[file]);
       });
       next();


### PR DESCRIPTION
Tests were failing on Windows, and `getCandidatesFromMapping` in yeoman/grunt-usemin@v2.0 was unable to resolve paths. This fixes the paths in summary, and restores usemin for Windows users.
