### PR TITLE
Display new file name

### DIFF
--- a/tasks/filerev.js
+++ b/tasks/filerev.js
@@ -49,7 +49,7 @@ module.exports = function (grunt) {
         }
 
         filerev.summary[path.normalize(file)] = path.join(dirname, newName);
-        grunt.log.writeln('✔ '.green + file + (' changed to ').grey + filerev.summary[file]);
+        grunt.log.writeln('✔ '.green + file + (' changed to ').grey + newName);
       });
       next();
     }, this.async());


### PR DESCRIPTION
It was showing "changed to undefined", "changed to undefined", "changed to undefined"... because the keys in the map are different.

`filerev.summary[path.normalize(file)]` is different from `filerev.summary[file]`
