### PR TITLE
Check if expand is used to define files

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -39,6 +39,12 @@ module.exports = function (grunt) {
         src: ['test/fixtures/file.png'],
         dest: 'test/tmp/dest'
       },
+      withExpand: {
+        expand: true,
+        cwd: 'test/fixtures',
+        src: ['*.png'],
+        dest: 'test/tmp/expand'
+      },
       withSummaryAttributeName: {
         options: {
           summary: 'foo'

--- a/tasks/filerev.js
+++ b/tasks/filerev.js
@@ -19,6 +19,11 @@ module.exports = function (grunt) {
     eachAsync(this.files, function (el, i, next) {
       // If dest is furnished it should indicate a directory
       if (el.dest) {
+        // When globbing is used, el.dest contains basename, we remove it
+        if(el.orig.expand) {
+          el.dest = path.dirname(el.dest);
+        }
+
         try {
           var stat = fs.lstatSync(el.dest);
           if (stat && !stat.isDirectory()) {

--- a/test/filerev_test.js
+++ b/test/filerev_test.js
@@ -20,4 +20,10 @@ describe('filerev', function () {
     var revisioned= fs.statSync('test/tmp/dest/file.a0539763.png').size;
     assert(revisioned === original);
   });
+
+  it('should allow sources defined with expand', function () {
+    var original = fs.statSync('test/fixtures/file.png').size;
+    var revisioned= fs.statSync('test/tmp/expand/file.a0539763.png').size;
+    assert(revisioned === original);
+  });
 });


### PR DESCRIPTION
When we use a globbling pattern with expand to define all sources, el.dest in filerev task contains the basename too.

Example with this conf :

```
filerev: {
  files: {
    expand: true,
    cwd: 'test/fixtures',
    src: ['*.png'], // ex. file.png
    dest: 'test/tmp/expand'
 }
}
```

```
Destination dir test/tmp/expand/another.png does not exists for target withExpand: creating
✔ test/fixtures/another.png changed to another.d9170849.png
Destination dir test/tmp/expand/cfgfile.png does not exists for target withExpand: creating
✔ test/fixtures/cfgfile.png changed to cfgfile.a0539763.png
Destination dir test/tmp/expand/file.png does not exists for target withExpand: creating
✔ test/fixtures/file.png changed to file.a0539763.png
```

Finally filerev copy `test/fixtures/another.png` to `test/tmp/expand/another.png/another.d9170849.png`

I had a test and a fix proposal to change this behaviour.
