### PR TITLE
Added option.rename that allows not renaming the files but keeping the summary

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,13 @@ Default: `8`
 
 The number of characters of the file hash to prefix the file name with.
 
+#### options.rename
+
+Type: `Boolean`
+Default: `true`
+
+In case no need to rewrite file names but handle the redirection using the webserver, set rename to false and it will only lead to rewriting the refrences without renaming the files
+
 ### Destination
 
 It will overwrite the `src` files if you don't specify a `dest`:

--- a/tasks/filerev.js
+++ b/tasks/filerev.js
@@ -10,7 +10,8 @@ module.exports = function (grunt) {
     var options = this.options({
       encoding: 'utf8',
       algorithm: 'md5',
-      length: 8
+      length: 8,
+      rename: true  
     });
     var target = this.target;
     var filerev = grunt.filerev || {summary: {}};
@@ -48,11 +49,15 @@ module.exports = function (grunt) {
 
         if (move) {
           dirname = path.dirname(file);
-          resultPath = path.resolve(dirname, newName);
+          if (options.rename === true){
+              resultPath = path.resolve(dirname, newName);
+          }
           fs.renameSync(file, resultPath);
         } else {
           dirname = el.dest;
-          resultPath = path.resolve(dirname, newName);
+          if (options.rename === true){
+              resultPath = path.resolve(dirname, newName);
+          }
           grunt.file.copy(file, resultPath);
         }
 


### PR DESCRIPTION
I needed to rename the references without renaming the files because i am handling that in webserver, and since other projects link to my code i cannot force them to rename the references every time i build
