### PR TITLE
Rev full asset directory

### DIFF
--- a/tasks/filerev.js
+++ b/tasks/filerev.js
@@ -8,15 +8,15 @@ var eachAsync = require('each-async');
 module.exports = function (grunt) {
   function makeHash(filepath, algorithm, fileEncoding, encoding) {
     var hash = crypto.createHash(algorithm);
-  	if (grunt.file.isDir(filepath)) {
-	  	grunt.file.recurse(filepath, function (abspath) {
-		  	grunt.log.verbose.write('Hashing ' + abspath + '...');
-			  hash.update(grunt.file.read(abspath), fileEncoding);
-	  	});
-	  } else {
-	  	grunt.log.verbose.write('Hashing ' + filepath + '...');
-	  	hash.update(grunt.file.read(filepath), fileEncoding);
-	  }
+    if (grunt.file.isDir(filepath)) {
+      grunt.file.recurse(filepath, function (abspath) {
+        grunt.log.verbose.write('Hashing ' + abspath + '...');
+        hash.update(grunt.file.read(abspath), fileEncoding);
+      });
+    } else {
+      grunt.log.verbose.write('Hashing ' + filepath + '...');
+      hash.update(grunt.file.read(filepath), fileEncoding);
+    }
     return hash.digest(encoding);
   }
   grunt.registerMultiTask('filerev', 'File revisioning based on content hashing', function () {


### PR DESCRIPTION
I have a directory with localization files. The filename is used to select the correct file for a locale, so it should remain the same. Instead the directory name can be changed in a similar manner, so:

  dir/file-en.json -> dir.a2aa178/file-en.json
  dir/file-nl.json -> dir.a2aa178/file-nl.json

the hash is based on the full contents of the directory.