### PR TITLE
Ignore directories when using file expansion

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -42,7 +42,7 @@ module.exports = function (grunt) {
       withExpand: {
         expand: true,
         cwd: 'test/fixtures',
-        src: ['*.png'],
+        src: ['*'],
         dest: 'test/tmp/expand'
       },
       withSummaryAttributeName: {

--- a/tasks/filerev.js
+++ b/tasks/filerev.js
@@ -17,7 +17,7 @@ module.exports = function (grunt) {
 
     eachAsync(this.files, function (el, i, next) {
       var move = true;
-      
+
       // If dest is furnished it should indicate a directory
       if (el.dest) {
         // When globbing is used, el.dest contains basename, we remove it
@@ -39,6 +39,9 @@ module.exports = function (grunt) {
       }
 
       el.src.forEach(function (file) {
+        if (grunt.file.isDir(file)) {
+          return;
+        }
         var dirname;
         var hash = crypto.createHash(options.algorithm).update(grunt.file.read(file), options.encoding).digest('hex');
         var suffix = hash.slice(0, options.length);

--- a/test/fixtures/dir/.gitkeep
+++ b/test/fixtures/dir/.gitkeep
@@ -1,0 +1,1 @@
+.gitkeep


### PR DESCRIPTION
I added an empty dir to the fixtures and captured it in the expand target to verify that the change works.
