### PR TITLE
Fixing a regression bug

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -81,6 +81,7 @@ module.exports = function (grunt) {
 
   grunt.registerTask('checkSummary', 'Check that summary attribute is correctly created', function () {
     var src = path.normalize('test/fixtures/file.png');
-    assert.ok(grunt.filerev.summary[src]);
+    var expected = path.normalize('test/tmp/file.d01d8f48.png');
+    assert.equal(grunt.filerev.summary[src], expected);
   });
 };

--- a/package.json
+++ b/package.json
@@ -24,8 +24,7 @@
   ],
   "dependencies": {
     "chalk": "^0.5.1",
-    "each-async": "^0.1.3",
-    "semver": "^3.0.1"
+    "each-async": "^0.1.3"
   },
   "devDependencies": {
     "grunt": "^0.4.5",

--- a/test/test.js
+++ b/test/test.js
@@ -1,13 +1,10 @@
 'use strict';
 var fs = require('fs');
-var semver = require('semver');
 var assert = require('assert');
 
-// http://blog.nodejs.org/2014/06/16/openssl-and-breaking-utf-8-change/
-var useBrokenUTF = (typeof process.env.NODE_INVALID_UTF8 !== 'undefined' || semver.lt(process.version, '0.10.29'));
 var hashes = {
-  'test/fixtures/file.png' : useBrokenUTF ? 'test/tmp/file.a0539763.png' : 'test/tmp/file.d01d8f48.png',
-  'test/fixtures/cfgfile.png' : useBrokenUTF ? 'test/tmp/cfgfile.f64f.png' : 'test/tmp/cfgfile.46a6.png'
+  'test/fixtures/file.png' : 'test/tmp/file.d01d8f48.png',
+  'test/fixtures/cfgfile.png' : 'test/tmp/cfgfile.46a6.png'
 };
 
 it('should revision files based on content', function () {


### PR DESCRIPTION
When removing the ~ (tilde) syntax from `package.json`, it was not replaced with thew new ^ syntax.
Version 0.2.1 therefore was using 0.1.3 of each-async, while Version 1.0 regressed to 0.1.0 of each-async.
- Adds ^ syntax to each-async
- Sets minimum each-async to 0.1.3

_Note_ Tests are failing for me. The hashes for md5 do not match what's in the test cases. This looks more like an issue with the previous hashes using crypto.createHash at a different version with (somehow?) different output. I cannot explain that.

Fixes #39 
