### PR TITLE
Add support and test for output filename template.

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -45,6 +45,15 @@ module.exports = function (grunt) {
         src: ['*'],
         dest: 'test/tmp/expand'
       },
+      withFilenameProcessing: {
+        options: {
+          process: function(name, hash, extension) {
+            return name + '-processed-' + hash + '.' + extension;
+          }
+        },
+        src: ['test/fixtures/another.png'],
+        dest: 'test/tmp'
+      },
       withSummaryAttributeName: {
         options: {
           summary: 'foo'

--- a/tasks/filerev.js
+++ b/tasks/filerev.js
@@ -46,7 +46,18 @@ module.exports = function (grunt) {
         var hash = crypto.createHash(options.algorithm).update(fs.readFileSync(file)).digest('hex');
         var suffix = hash.slice(0, options.length);
         var ext = path.extname(file);
-        var newName = [path.basename(file, ext), suffix, ext.slice(1)].join('.');
+        var newName;
+
+        if (typeof options.process === 'function') {
+          newName = options.process(path.basename(file, ext), suffix, ext.slice(1));
+        } else {
+          if (options.process) {
+            grunt.log.error('options.process must be a function; ignoring');
+          }
+
+          newName = [path.basename(file, ext), suffix, ext.slice(1)].join('.');
+        }
+
         var resultPath;
 
         if (move) {

--- a/test/test.js
+++ b/test/test.js
@@ -7,7 +7,8 @@ var hashes = {
   'test/fixtures/cfgfile.png' : 'test/tmp/cfgfile.da63.png',
   'test/fixtures/math.js' : 'test/tmp/withSourceMaps/math.2f56179e.js',
   'test/fixtures/math.js.map' : 'test/tmp/withSourceMaps/math.2f56179e.js.map',
-  'test/fixtures/physics.js' : 'test/tmp/withSourceMaps/physics.14a0a482.js'
+  'test/fixtures/physics.js' : 'test/tmp/withSourceMaps/physics.14a0a482.js',
+  'test/fixtures/another.png' : 'test/tmp/another-processed-92279d3f.png'
 };
 
 it('should revision files based on content', function () {
@@ -52,3 +53,9 @@ it('should revision .js file ok without any .map', function () {
   assert(revisioned === original);
 });
 
+it('should allow a filename processing function', function () {
+  var file = 'test/fixtures/another.png';
+  var original = fs.statSync(file).size;
+  var revisioned = fs.statSync(hashes[file]).size;
+  assert(revisioned === original);
+});


### PR DESCRIPTION
I found that grunt-filerev seemed to be the best plugin to add a hash to my production files, but I found the naming scheme too restrictive. We already used a filename-hash.js format, and other components in the pipeline rely on that which would be significant effort to update.

To that end, I've added support for using a mustache template to generate the output filename. Original filename, hash and original extension are made available to the template - though I can imagine other useful information that could be made available in future (e.g. current date or time).

One curio - the unit tests don't pass on my local build for 2 reasons:
1. They are never run, no tasks following filerev seem to get run. It seems @dannymarshland had a similar issue in his fork and fixed it with this commit https://github.com/dannymarsland/grunt-filerev/commit/bc5ccfa751f78218292ee0909b497f8c8c15cd85
2. The file hashes are different on my machine to those listed in the tests, e.g. where the test expects a0539763 I get d01d8f48. I can only assume this is some odd system dependency (I'm on win32 here). I've used the original expected hashes in my test which should work. Just thought I'd point this one out.

Note: this replaces https://github.com/yeoman/grunt-filerev/pull/45