### PR TITLE
Use encoding from options on read.

### DIFF
--- a/tasks/filerev.js
+++ b/tasks/filerev.js
@@ -44,7 +44,9 @@ module.exports = function (grunt) {
         }
 
         var dirname;
-        var hash = crypto.createHash(options.algorithm).update(grunt.file.read(file), options.encoding).digest('hex');
+        var hash = crypto.createHash(options.algorithm).update(grunt.file.read(file, {
+          encoding: options.encoding
+        }), options.encoding).digest('hex');
         var suffix = hash.slice(0, options.length);
         var ext = path.extname(file);
         var newName = [path.basename(file, ext), suffix, ext.slice(1)].join('.');


### PR DESCRIPTION
Otherwise the hash is of the utf-8 interpretation of a binary file. For example:

```
$ openssl sha1 test/fixtures/file.png
SHA1(test/fixtures/file.png)= da63c1ef4358634812562d3732bad2a6941cd9ae
```

Is different from the test hash (a0539763). 
### Use case

I compare the hash w/ E-Tag in Amazon to know which version I'm deploying; that fails without this patch.
