### PR TITLE
fix(log): remove syntax error if one file is revved

### DIFF
--- a/tasks/filerev.js
+++ b/tasks/filerev.js
@@ -82,7 +82,10 @@ module.exports = function (grunt) {
         }
 
       });
-      grunt.log.writeln('Revved ' + chalk.cyan(el.src.length) + ' files');
+
+      grunt.log.writeln('Revved ' + chalk.cyan(el.src.length) + ' ' +
+        el.src.length === 1 ? 'file' : 'files'
+      );
 
       next();
     }, this.async());


### PR DESCRIPTION
Complete #59 following [comment](https://github.com/yeoman/grunt-usemin/pull/467#issuecomment-60562245) from @XhmikosR in yeoman/grunt-usemin#467
