### PR TITLE
fix(log): add missing parenthesis

### DIFF
--- a/tasks/filerev.js
+++ b/tasks/filerev.js
@@ -84,7 +84,7 @@ module.exports = function (grunt) {
       });
 
       grunt.log.writeln('Revved ' + chalk.cyan(el.src.length) + ' ' +
-        el.src.length === 1 ? 'file' : 'files'
+        (el.src.length === 1 ? 'file' : 'files')
       );
 
       next();


### PR DESCRIPTION
The log output was only showing “file” or “files”.
