### PR TITLE
rewrite the sourceMappingURL in maps

### DIFF
--- a/tasks/filerev.js
+++ b/tasks/filerev.js
@@ -63,15 +63,23 @@ module.exports = function (grunt) {
         var sourceMap = false;
         if (ext === '.js' || ext === '.css') {
             var map = file + '.map';
-            resultPath += '.map';
+            var resultPathMap = resultPath + '.map';
             if (grunt.file.exists(map)) {
                 if (move) {
-                    fs.renameSync(map, resultPath);
+                    fs.renameSync(map, resultPathMap);
                 } else {
-                    grunt.file.copy(map, resultPath);
+                    grunt.file.copy(map, resultPathMap);
                 }
+
+                // rewrite the sourceMappingURL in files
+                var jsFileContents = fs.readFileSync(resultPath, {
+                    encoding: 'utf8'
+                });
+                var updatedFile = jsFileContents.replace(path.basename(map), path.basename(resultPathMap));
+                fs.writeFileSync(resultPath, updatedFile);
+
                 sourceMap = true;
-           }
+            }
         }
 
         filerev.summary[path.normalize(file)] = path.join(dirname, newName);


### PR DESCRIPTION
Currently, when the filerev encounter sourcemaps, it will rename the sourcemaps. However, it will not rename the reference to the sourcemaps within the actual js file. This would result in browser 404s for these source maps.

This fix reads the file contents and updates the sourecemap names with the `rev`d name.