### PR TITLE
Added unix line ending in test fixtures so test will pass on Windows

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,1 +1,3 @@
 * text=auto
+/test/fixtures/*.js text eol=lf
+/test/fixtures/*.map text eol=lf


### PR DESCRIPTION
Since there was * text=auto in .gitattributes, end of a line was changed to CRLF on Windows machines. This was causing incorrect hash since file content changed. Updated .gitattributes so js and map files have original LF end of a line.