### PR TITLE
Store filerev summary to file and strip summary paths

### DIFF
--- a/tasks/filerev.js
+++ b/tasks/filerev.js
@@ -27,9 +27,10 @@ module.exports = function (grunt) {
         try {
           var stat = fs.lstatSync(el.dest);
           if (stat && !stat.isDirectory()) {
-            grunt.fail.fatal('Destination ' + el.dest  + ' for target ' + target + ' is not a directory');
+            grunt.fail.fatal('Destination ' + el.dest + ' for target ' + target + ' is not a directory');
           }
-        } catch (err) {
+        }
+        catch (err) {
           grunt.verbose.writeln('Destination dir ' + el.dest + ' does not exists for target ' + target + ': creating');
           grunt.file.mkdir(el.dest);
         }
@@ -50,12 +51,17 @@ module.exports = function (grunt) {
 
         if (typeof options.process === 'function') {
           newName = options.process(path.basename(file, ext), suffix, ext.slice(1));
-        } else {
+        }
+        else {
           if (options.process) {
             grunt.log.error('options.process must be a function; ignoring');
           }
 
-          newName = [path.basename(file, ext), suffix, ext.slice(1)].join('.');
+          newName = [
+            path.basename(file, ext),
+            suffix,
+            ext.slice(1)
+          ].join('.');
         }
 
         var resultPath;
@@ -64,7 +70,8 @@ module.exports = function (grunt) {
           dirname = path.dirname(file);
           resultPath = path.resolve(dirname, newName);
           fs.renameSync(file, resultPath);
-        } else {
+        }
+        else {
           dirname = el.dest;
           resultPath = path.resolve(dirname, newName);
           grunt.file.copy(file, resultPath);
@@ -78,7 +85,8 @@ module.exports = function (grunt) {
           if (grunt.file.exists(map)) {
             if (move) {
               fs.renameSync(map, resultPath);
-            } else {
+            }
+            else {
               grunt.file.copy(map, resultPath);
             }
             sourceMap = true;
@@ -101,32 +109,39 @@ module.exports = function (grunt) {
       next();
     }, this.async());
 
-    if (options.summaryFilePath) {
+    if (options.stripPath) {
       // modify filerev summary
-      var customSummary = {};
+      var strippedSummary = {};
 
-      _.forEach(filerev.summary, function(value, key) {
-        var src;
-        var dest;
-        if (_.isObject(options.stripPath)){
-          if (options.stripPath.src) {
-            src = options.stripPath.src;
+      for (var key in filerev.summary) {
+        if (filerev.summary.hasOwnProperty(key)) {
+          var src;
+          var dest;
+          if (typeof options.stripPath === 'object') {
+            if (options.stripPath.src) {
+              src = options.stripPath.src;
+            }
+            if (options.stripPath.dest) {
+              dest = options.stripPath.dest;
+            }
           }
-          if (options.stripPath.dest) {
-            dest = options.stripPath.dest;
+          else {
+            src = options.stripPath;
+            dest = options.stripPath;
           }
+          var value = filerev.summary[key];
+          value = value.replace(dest, '');
+          key = key.replace(src, '');
+          strippedSummary[key] = value;
         }
-        else {
-          src = options.stripPath;
-          dest = options.stripPath;
-        }
-        key = key.replace(src, '');
-        value = value.replace(dest, '');
-        customSummary[key] = value;
-      });
+      }
 
+      filerev.summary = strippedSummary;
+    }
+
+    if (options.summaryFilePath) {
       // write filerev summary into file
-      fs.writeFileSync(options.summaryFilePath, JSON.stringify(customSummary, null, 4));
+      fs.writeFileSync(options.summaryFilePath, JSON.stringify(filerev.summary, null, 4));
       grunt.log.writeln('Filerev summary was stored to ' + options.summaryFilePath);
     }
 

--- a/tasks/filerev.js
+++ b/tasks/filerev.js
@@ -101,6 +101,35 @@ module.exports = function (grunt) {
       next();
     }, this.async());
 
+    if (options.summaryFilePath) {
+      // modify filerev summary
+      var customSummary = {};
+
+      _.forEach(filerev.summary, function(value, key) {
+        var src;
+        var dest;
+        if (_.isObject(options.stripPath)){
+          if (options.stripPath.src) {
+            src = options.stripPath.src;
+          }
+          if (options.stripPath.dest) {
+            dest = options.stripPath.dest;
+          }
+        }
+        else {
+          src = options.stripPath;
+          dest = options.stripPath;
+        }
+        key = key.replace(src, '');
+        value = value.replace(dest, '');
+        customSummary[key] = value;
+      });
+
+      // write filerev summary into file
+      fs.writeFileSync(options.summaryFilePath, JSON.stringify(customSummary, null, 4));
+      grunt.log.writeln('Filerev summary was stored to ' + options.summaryFilePath);
+    }
+
     grunt.filerev = filerev;
   });
 };


### PR DESCRIPTION
This feature offers two possibility:
 - storing the filerev summary to a file
 - stripping the src/dest paths of the filerev summary

Therefore two option parameters are supported:
 - summaryFilePath
 - stripPath

**summaryFilePath** defines the path, where the filerev summary should be stored.
**stripPath** can be used to strip the src/dest summary paths. The value can either be a string, or an object with the properties **src** and **dest**. If only a string is passed, this string is removed from all src and dest paths. If an object is passed, src and dest paths get treated individually.

**Example:**

````
options: {
      algorithm: 'md5',
      length: 8,
      summaryFilePath: './tasks/filerevsummary.json',
      stripPath: {
        src: 'assets',
        dest: '.tmp/public'
      }
    },
```

**My use-case:**
I implemented this feature because I needed the filerev summary in a view helper to provide the hashed source path when a view gets loaded. Therefore the summary had to be stored somewhere locally.