### PR TITLE
More stable sourcemap filerevving

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -74,7 +74,7 @@ module.exports = function (grunt) {
       withSourceMaps: {
         expand: true,
         cwd: 'test/fixtures',
-        src: ['*.js'],
+        src: ['*.js', '*.css'],
         dest: 'test/tmp/withSourceMaps'
       }
     },

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
   ],
   "dependencies": {
     "chalk": "^1.0.0",
+    "convert-source-map": "^1.0.0",
     "each-async": "^0.1.3"
   },
   "devDependencies": {

--- a/tasks/filerev.js
+++ b/tasks/filerev.js
@@ -4,6 +4,7 @@ var path = require('path');
 var fs = require('fs');
 var chalk = require('chalk');
 var eachAsync = require('each-async');
+var convert = require('convert-source-map');
 
 module.exports = function (grunt) {
   grunt.registerMultiTask('filerev', 'File revisioning based on content hashing', function () {
@@ -87,7 +88,11 @@ module.exports = function (grunt) {
 
             // rewrite the sourceMappingURL in files
             var fileContents = grunt.file.read(resultPath, {encoding: 'utf8'});
-            var newSrcMap = fileContents.replace('//# sourceMappingURL=' + path.basename(file) + '.map', '//# sourceMappingURL=' + path.basename(resultPathMap));
+            // use regex that matches single-line and multi-line sourcemap urls
+            // note: this will ignore inline base64-encoded sourcemaps
+            var matches = convert.mapFileCommentRegex.exec(fileContents);
+            var sourceMapFile = matches[1] || matches[2]; // 1st is single line, 2nd is multiline
+            var newSrcMap = fileContents.replace(sourceMapFile, path.basename(resultPathMap));
             grunt.file.write(resultPath, newSrcMap, {encoding: 'utf8'});
             sourceMap = true;
           }

--- a/test/fixtures/inline.js
+++ b/test/fixtures/inline.js
@@ -1,0 +1,2 @@
+'use strict';window.sqrt = Math.sqrt;
+//# sourceMappingURL=data:application/json;base64,eyJ2ZXJzaW9uIjozLCJmaWxlIjoiaW5saW5lLmpzIiwic291cmNlcyI6WyJpbmxpbmUuanMiXSwibmFtZXMiOlsid2luZG93Iiwic3FydCIsIk1hdGgiXSwibWFwcGluZ3MiOiJBQUFBLFlBQ0FBLFFBQU9DLEtBQU9DLEtBQUtEIn0=

--- a/test/fixtures/more-styles.css
+++ b/test/fixtures/more-styles.css
@@ -1,0 +1,1 @@
+.more-styles{color:#fff}

--- a/test/fixtures/styles.css
+++ b/test/fixtures/styles.css
@@ -1,0 +1,1 @@
+div{width:100%;height:100%;color:#fff}/*# sourceMappingURL=styles.css.map */

--- a/test/fixtures/styles.css.map
+++ b/test/fixtures/styles.css.map
@@ -1,0 +1,1 @@
+{"version":3,"sources":["styles.css"],"names":[],"mappings":"AAAA,IACE,WACA,YACA"}

--- a/test/test.js
+++ b/test/test.js
@@ -8,6 +8,10 @@ var hashes = {
   'test/fixtures/math.js' : 'test/tmp/withSourceMaps/math.6272e937.js',
   'test/fixtures/math.js.map' : 'test/tmp/withSourceMaps/math.6272e937.js.map',
   'test/fixtures/physics.js' : 'test/tmp/withSourceMaps/physics.28cb15fd.js',
+  'test/fixtures/styles.css' : 'test/tmp/withSourceMaps/styles.a6aa2292.css',
+  'test/fixtures/styles.css.map' : 'test/tmp/withSourceMaps/styles.a6aa2292.css.map',
+  'test/fixtures/more-styles.css' : 'test/tmp/withSourceMaps/more-styles.dce8e0e5.css',
+  'test/fixtures/inline.js' : 'test/tmp/withSourceMaps/inline.8b435ef2.js',
   'test/fixtures/another.png' : 'test/tmp/another-processed-92279d3f.png'
 };
 
@@ -55,6 +59,34 @@ it('should point the .js sourceMappingURL to the revisioned .map', function () {
 
 it('should revision .js file ok without any .map', function () {
   var file = 'test/fixtures/physics.js';
+  var original = fs.statSync(file).size;
+  var revisioned = fs.statSync(hashes[file]).size;
+  assert(revisioned === original);
+});
+
+it('should use same revision as .css source for the .map', function () {
+  var file = 'test/fixtures/styles.css.map';
+  var original = fs.statSync(file).size;
+  var revisioned = fs.statSync(hashes[file]).size;
+  assert(revisioned === original);
+});
+
+it('should point the .css sourceMappingURL to the revisioned .map', function () {
+  var file = 'test/fixtures/styles.css';
+  var map = 'styles.a6aa2292.css.map';
+  var revisioned = fs.readFileSync(hashes[file], {encoding: 'utf8'});
+  assert(revisioned.indexOf('/*# sourceMappingURL=' + map) !== -1);
+});
+
+it('should revision .css file ok without any .map', function () {
+  var file = 'test/fixtures/more-styles.css';
+  var original = fs.statSync(file).size;
+  var revisioned = fs.statSync(hashes[file]).size;
+  assert(revisioned === original);
+});
+
+it('should ignore inline base64-encoded sourcemaps', function () {
+  var file = 'test/fixtures/inline.js';
   var original = fs.statSync(file).size;
   var revisioned = fs.statSync(hashes[file]).size;
   assert(revisioned === original);


### PR DESCRIPTION
* Adds support for multi-line sourcemap comments (as in CSS, addresses [travi's issue here](https://github.com/yeoman/grunt-filerev/issues/62#issuecomment-85128495))
* Ignores inline base64-encoded sourcemaps
* Includes tests to prove both of the above