### PR TITLE
expose srcDirname to process function

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ Default: `8`
 
 The number of characters of the file hash to prefix the file name with.
 
-#### options.process(basename, name, extension)
+#### options.process(basename, name, extension, srcDirname)
 
 Type: `function`  
 Default: `null`  

--- a/tasks/filerev.js
+++ b/tasks/filerev.js
@@ -29,7 +29,7 @@ module.exports = function (grunt) {
           var stat = fs.lstatSync(el.dest);
 
           if (stat && !stat.isDirectory()) {
-            grunt.fail.fatal('Destination ' + el.dest  + ' for target ' + target + ' is not a directory');
+            grunt.fail.fatal('Destination ' + el.dest + ' for target ' + target + ' is not a directory');
           }
         } catch (err) {
           grunt.verbose.writeln('Destination dir ' + el.dest + ' does not exists for target ' + target + ': creating');
@@ -51,7 +51,7 @@ module.exports = function (grunt) {
         var newName;
 
         if (typeof options.process === 'function') {
-          newName = options.process(path.basename(file, ext), suffix, ext.slice(1));
+          newName = options.process(path.basename(file, ext), suffix, ext.slice(1), path.dirname(file));
         } else {
           if (options.process) {
             grunt.log.error('options.process must be a function; ignoring');


### PR DESCRIPTION
Sometimes it can be useful to get the original path to the revved file in order to return the new name. i.e. if want to keep the file at the same place. Passing the original dirname to the process function allows to handle this scenario.