### PR TITLE
remove redundant output when expanding files

### DIFF
--- a/tasks/filerev.js
+++ b/tasks/filerev.js
@@ -8,6 +8,8 @@ var convert = require('convert-source-map');
 
 module.exports = function (grunt) {
   grunt.registerMultiTask('filerev', 'File revisioning based on content hashing', function () {
+    var done = this.async();
+    var revvedFilesCount = 0;
     var target = this.target;
     var filerev = grunt.filerev || {summary: {}};
     var options = this.options({
@@ -110,12 +112,16 @@ module.exports = function (grunt) {
         }
       });
 
-      grunt.log.writeln('Revved ' + chalk.cyan(el.src.length) + ' ' +
-        (el.src.length === 1 ? 'file' : 'files')
-      );
+      revvedFilesCount += el.src.length;
 
       next();
-    }, this.async());
+    }, function () {
+      grunt.log.writeln('Revved ' + chalk.cyan(revvedFilesCount) + ' ' +
+        (revvedFilesCount === 1 ? 'file' : 'files')
+      );
+
+      done();
+    });
 
     grunt.filerev = filerev;
   });


### PR DESCRIPTION
## Before

```
Running "filerev:compile" (filerev) task
Revved 1 file

Running "filerev:withConfig" (filerev) task
Revved 1 file

Running "filerev:withDest" (filerev) task
Revved 1 file

Running "filerev:withExpand" (filerev) task
Revved 1 file
Revved 1 file
Revved 1 file
Revved 1 file
Revved 1 file
Revved 1 file
Revved 1 file
Revved 1 file
Revved 1 file
Revved 1 file
Revved 1 file

Running "filerev:withFilenameProcessing" (filerev) task
Revved 1 file

Running "filerev:withSummaryAttributeName" (filerev) task
Revved 2 files

Running "filerev:withSourceMaps" (filerev) task
Revved 1 file
Revved 1 file
Revved 1 file
Revved 1 file
Revved 1 file
```
## After

```
Running "filerev:compile" (filerev) task
Revved 1 file

Running "filerev:withConfig" (filerev) task
Revved 1 file

Running "filerev:withDest" (filerev) task
Revved 1 file

Running "filerev:withExpand" (filerev) task
Revved 11 files

Running "filerev:withFilenameProcessing" (filerev) task
Revved 1 file

Running "filerev:withSummaryAttributeName" (filerev) task
Revved 2 files

Running "filerev:withSourceMaps" (filerev) task
Revved 5 files
```
